### PR TITLE
fix: change companion IP to 127.0.0.1

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,7 +72,7 @@ $SD.on("connected", (jsn) => {
     companionClient = new CompanionConnection();
 
     // In the future, let people select external companion
-    companionClient.setAddress("10.42.13.197");
+    companionClient.setAddress("127.0.0.1");
 
     companionClient.on("wrongversion", () => {
       for (let ctx in actionItems) {


### PR DESCRIPTION
This was accidentally changed to another IP here:
https://github.com/bitfocus/io.bitfocus.companion-plugin/commit/a28f02d2cb0c1b1397eb4acff46b638751169663#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fR56